### PR TITLE
create dedicated class for txt mail and for html mail body.

### DIFF
--- a/code/app/com/feth/play/module/mail/Mailer.java
+++ b/code/app/com/feth/play/module/mail/Mailer.java
@@ -86,6 +86,24 @@ public class Mailer {
 
     public static class Mail {
 
+
+        public static class HtmlBody  extends  Body{
+
+            public HtmlBody(final String text) {
+                super(null, text);
+            }
+
+        }
+
+        public static class TxtBody  extends  Body{
+
+            public TxtBody(final String text) {
+                super(text, null);
+            }
+
+        }
+
+
         public static class Body {
             private final String html;
             private final String text;


### PR DESCRIPTION
I created a dedicated class for a text body and for a html body.
It avoids having this in your code:
Body myBody = new Body(null,"myhtmlcode");
or
Body myBody = new Body("mytxtcode", null);
