### PR TITLE
Set JAVA_HOME to version 1.6, when publishing

### DIFF
--- a/code/build.sbt
+++ b/code/build.sbt
@@ -8,8 +8,6 @@ scalaVersion := "2.11.1"
 
 crossScalaVersions := Seq("2.10.4", "2.11.1")
 
-javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
-
 version := "0.6.3-SNAPSHOT"
 
 publishTo <<= (version) { version: String =>

--- a/code/publish.sh
+++ b/code/publish.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+JAVA_HOME=$(/usr/libexec/java_home -v 1.6)
 sbt +publish


### PR DESCRIPTION
To address joscha/play-easymail#19.
It's better to set the JAVA_HOME than using the bootstrap class path with a different compiler.
