### PR TITLE
Bugfix: Delay setting was placed wrong

### DIFF
--- a/code/conf/reference.conf
+++ b/code/conf/reference.conf
@@ -4,16 +4,16 @@ play-easymail {
 
     # Whether to add the X-Mailer header or not
     includeXMailerHeader=true
-    
+
+    # Seconds between sending mail through Akka
+    delay=1
+
     from {
         # Mailing from address
         email="play-easymail+no-reply@gmail.com"
 
         # Mailing name
         name="play-easymail"
-
-        # Seconds between sending mail through Akka
-        delay=1
     }
 }
 

--- a/samples/play-easymail-usage/conf/play-easymail.conf
+++ b/samples/play-easymail-usage/conf/play-easymail.conf
@@ -1,12 +1,13 @@
 play-easymail {
+
+    # Seconds between sending mail through Akka (defaults to 1)
+    # delay=1
+
     from {
         # Mailing from address
         email="you@gmail.com"
 
         # Mailing name
         name="Your Name"
-
-        # Seconds between sending mail through Akka (defaults to 1)
-        # delay=1
     }
 }


### PR DESCRIPTION
The `delay` setting was placed under the `from` clause, which is wrong. Have a look at [Mailer.java](https://github.com/joscha/play-easymail/blob/master/code/app/com/feth/play/module/mail/Mailer.java#L83) - it definitly does **not** get read from `fromConfig`.
