### PR TITLE
Upgrade play-plugins-mailer

### DIFF
--- a/code/build.sbt
+++ b/code/build.sbt
@@ -21,7 +21,7 @@ publishTo <<= (version) { version: String =>
 }
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play.plugins" %% "play-plugins-mailer" % "2.3.0"
+  "com.typesafe.play.plugins" %% "play-plugins-mailer" % "2.3.1"
 )
 
 publishArtifact in packageDoc := false


### PR DESCRIPTION
play-plugins-mailer 2.3.1 was released just now. It has some major improvements like finally got attachment support, debugging can be enabled and some nasty bugs got fixed. [Here](https://github.com/typesafehub/play-plugins/compare/mailer-2.3.0...mailer-2.3.1) is the diff.
@joscha Do you think it makes sense to also implement the attachment functionality into `play-easymail` or should people use the "base" library for it instead?
