### PR TITLE
Upgrade play-mailer and use new play-mailer repo

### DIFF
--- a/code/build.sbt
+++ b/code/build.sbt
@@ -9,7 +9,7 @@ scalaVersion := "2.11.2"
 crossScalaVersions := Seq("2.10.4", "2.11.2")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play.plugins" %% "play-plugins-mailer" % "2.3.1"
+  "com.typesafe.play" %% "play-mailer" % "2.4.1"
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)

--- a/code/conf/play.plugins
+++ b/code/conf/play.plugins
@@ -1,1 +1,1 @@
-1500:com.typesafe.plugin.CommonsMailerPlugin
+1500:play.api.libs.mailer.CommonsMailerPlugin


### PR DESCRIPTION
The Play team [moved](https://github.com/typesafehub/play-plugins/tree/master/mailer) the repo of it's [mailer plugin](https://github.com/playframework/play-mailer).
Also a [new version](https://github.com/playframework/play-mailer/releases/tag/2.4.0) was released just a few hours ago.

This PR is just a quick refactoring to match the [changed API](https://github.com/playframework/play-mailer/compare/v2.3.1...2.4.0) (but does not yet update the samples). Probably the code could be refactored in a better way...

@joscha The new version now introduces an [Email class](https://github.com/playframework/play-mailer/blob/2.4.0/src/main/scala/play/libs/mailer/Email.java). Wouldn't this make "your" class `com.feth.play.module.mail.Mailer.Mail` obsolete?
Plus there is also [talk about implementing a `sendAsync` method](https://github.com/playframework/play-mailer/issues/13), maybe in future this can be reused in your library.

