### PR TITLE
Add support for Play 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This plugin uses concepts from [Play20StartApp][] to make sending emails (text, 
 #### Version information
 **play-easymail currently needs Play! Framework 2.x**
 
-play-easymail is cross-tested with Java 1.6 and Java 1.7
+play-easymail is cross-tested with Java 1.6, Java 1.7 and Java 1.8
 
-* The `master` branch contains the code for Play! Framework 2.3.x (play-easymail version `0.6.0` and up).
+* The `master` branch contains the code for Play! Framework 2.4.x (play-easymail version `0.7.0` and up).
+* The `2.3.x` branch contains the code for 2.3.x (play-easymail version `0.6 - 0.6.x`).
 * The `2.2.x` branch contains the code for 2.2.x (play-easymail version `0.5 - 0.5.x`).
 * The `2.1.x` branch contains the code for 2.1.x (play-easymail version `0.2 - 0.3.x`).
 * The `2.0.x` is a maintenance branch for the 2.0.x series of Play! Framework (play-easymail version `0.1`).
@@ -26,6 +27,10 @@ Mailer.getDefaultMailer().sendMail(
 You can also have a look at the [sample](samples/play-easymail-usage/app/controllers/Application.java) for a more advanced use-case (content from templates and setting custom headers).
 
 ## Versions
+* **0.7.0** [2014-10-28]
+  * Support for play 2.4.x
+  * Use of @Inject
+  * Use of new play-mailer-3.0.0
 * **0.6.6** [2014-10-28]
   * Fix delay setting location (thanks @mkurz)
   * Attachment support (thanks @mkurz)

--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ Mailer.getDefaultMailer().sendMail(
 You can also have a look at the [sample](samples/play-easymail-usage/app/controllers/Application.java) for a more advanced use-case (content from templates and setting custom headers).
 
 ## Versions
-* **0.7.0** [2014-10-28]
-  * Support for play 2.4.x
-  * Use of @Inject
-  * Use of new play-mailer-3.0.0
+* **0.7.0** [2015-06-09]
+  * Support for play 2.4.x (thanks @vmouta)
+  * Use of new play-mailer-3.x (thanks @vmouta)
 * **0.6.6** [2014-10-28]
   * Fix delay setting location (thanks @mkurz)
   * Attachment support (thanks @mkurz)

--- a/code/app/com/feth/play/module/mail/Mailer.java
+++ b/code/app/com/feth/play/module/mail/Mailer.java
@@ -1,21 +1,19 @@
 package com.feth.play.module.mail;
 
 import akka.actor.Cancellable;
-import com.feth.play.module.mail.Mailer.Mail.Body;
-import play.libs.mailer.Email;
-import play.libs.mailer.MailerPlugin;
 import play.Configuration;
 import play.libs.Akka;
+import play.libs.mailer.Email;
+import play.libs.mailer.MailerPlugin;
 import scala.concurrent.duration.Duration;
 import scala.concurrent.duration.FiniteDuration;
 
-import java.io.File;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 public class Mailer {
-
+	
     private static final String MAILER = "play-easymail/";
 
     private static final String CONFIG_BASE = "play-easymail";
@@ -76,6 +74,175 @@ public class Mailer {
 
         return sb.toString();
     }
+    
+    public static class Mail extends Email {
+        
+        
+        public static class HtmlBody extends Body {
+            
+            public HtmlBody(final String text) {
+                super(null, text);
+            }
+            
+        }
+        
+        public static class TxtBody extends Body {
+            
+            public TxtBody(final String text) {
+                super(text, null);
+            }
+            
+        }
+        
+        public static class Body {
+            private final String html;
+            private final String text;
+            private final boolean isHtml;
+            private final boolean isText;
+            
+            public Body(final String text) {
+                this(text, null);
+            }
+            
+            public Body(final String text, final String html) {
+                this.isHtml = html != null && !html.trim().isEmpty();
+                this.isText = text != null && !text.trim().isEmpty();
+                
+                if (!this.isHtml && !this.isText) {
+                    throw new RuntimeException(
+                                               "Text and HTML cannot both be empty or null");
+                }
+                this.html = (this.isHtml) ? html : null;
+                this.text = (this.isText) ? text : null;
+            }
+            
+            public boolean isHtml() {
+                return isHtml;
+            }
+            
+            public boolean isText() {
+                return isText;
+            }
+            
+            public boolean isBoth() {
+                return isText() && isHtml();
+            }
+            
+            public String getHtml() {
+                return html;
+            }
+            
+            public String getText() {
+                return text;
+            }
+        }
+        
+        public Mail(final String subject, final String body,
+                    final String recipients) {
+            this(subject, new Body(body), new String[]{recipients});
+        }
+        
+        public Mail(final String subject, final String body,
+                    final List<String> recipients) {
+            this(subject, new Body(body), recipients);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final String recipients) {
+            this(subject, body, new String[]{recipients});
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final String[] recipients) {
+            this(subject, body, Arrays.asList(recipients));
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients) {
+            this(subject, body, recipients, null, null, null, null);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients, final List<String> cc) {
+            this(subject, body, recipients, cc, null, null, null);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients, final List<String> cc, final List<String> bcc) {
+            this(subject, body, recipients, cc, bcc, null, null);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients, final String replyTo) {
+            this(subject, body, recipients, null, null, null, replyTo);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients, final List<String> cc, final String replyTo) {
+            this(subject, body, recipients, cc, null, null, replyTo);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients, final List<String> cc, final List<String> bcc, final String replyTo) {
+            this(subject, body, recipients, cc, bcc, null, replyTo);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients,
+                    final Map<String, List<String>> customHeaders) {
+            this(subject, body, recipients, null, null, customHeaders, null);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients, final List<String> cc,
+                    final Map<String, List<String>> customHeaders) {
+            this(subject, body, recipients, cc, null, customHeaders, null);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients, final List<String> cc, final List<String> bcc,
+                    final Map<String, List<String>> customHeaders) {
+            this(subject, body, recipients, cc, bcc, customHeaders, null);
+        }
+        
+        public Mail(final String subject, final Body body,
+                    final List<String> recipients, final List<String> cc, final List<String> bcc,
+                    final Map<String, List<String>> customHeaders, final String replyTo) {
+            if (subject == null || subject.trim().isEmpty()) {
+                throw new RuntimeException("Subject must not be null or empty");
+            }
+            this.setSubject(subject);
+            
+            if (body == null) {
+                throw new RuntimeException("Body must not be null or empty");
+            }
+            if(body.isText())this.setBodyText(body.getText());
+            if(body.isHtml())this.setBodyHtml(body.getHtml());
+            
+            if (recipients == null || recipients.size() == 0) {
+                throw new RuntimeException(
+                                           "There must be at least one recipient");
+            }
+            this.setTo(recipients);
+            
+            if (cc != null && cc.size() > 0) this.setCc(cc);
+            if (bcc != null && bcc.size() > 0) this.setBcc(bcc);
+            
+            if (customHeaders != null) {
+                for (final Entry<String, List<String>> entry : customHeaders.entrySet()) {
+                    final String headerName = entry.getKey();
+                    for (final String headerValue : entry.getValue()) {
+                        this.addHeader(headerName, headerValue);
+                    }
+                }
+            }
+            this.setReplyTo(replyTo);
+        }
+        
+        public Body getBody() {
+            return new Body(getBodyText(), getBodyHtml());
+        }
+    }
 
     protected Mailer(final Configuration config) {
         delay = Duration.create(config.getLong(SettingKeys.DELAY, 1L), TimeUnit.SECONDS);
@@ -85,291 +252,6 @@ public class Mailer {
                 fromConfig.getString(SettingKeys.FROM_NAME));
 
         includeXMailerHeader = config.getBoolean(SettingKeys.INCLUDE_XMAILER_HEADER, true);
-    }
-
-    public static class Mail {
-
-
-        public static class HtmlBody extends Body {
-
-            public HtmlBody(final String text) {
-                super(null, text);
-            }
-
-        }
-
-        public static class TxtBody extends Body {
-
-            public TxtBody(final String text) {
-                super(text, null);
-            }
-
-        }
-
-        public static class Body {
-            private final String html;
-            private final String text;
-            private final boolean isHtml;
-            private final boolean isText;
-
-            public Body(final String text) {
-                this(text, null);
-            }
-
-            public Body(final String text, final String html) {
-                this.isHtml = html != null && !html.trim().isEmpty();
-                this.isText = text != null && !text.trim().isEmpty();
-
-                if (!this.isHtml && !this.isText) {
-                    throw new RuntimeException(
-                            "Text and HTML cannot both be empty or null");
-                }
-                this.html = (this.isHtml) ? html : null;
-                this.text = (this.isText) ? text : null;
-            }
-
-            public boolean isHtml() {
-                return isHtml;
-            }
-
-            public boolean isText() {
-                return isText;
-            }
-
-            public boolean isBoth() {
-                return isText() && isHtml();
-            }
-
-            public String getHtml() {
-                return html;
-            }
-
-            public String getText() {
-                return text;
-            }
-        }
-
-        public static class Attachment {
-            private byte[] data;
-            private String mimeType;
-            private File file;
-            private String name;
-            private String description;
-            private String disposition;
-
-            public Attachment(final String name, final byte[] data, final String mimeType) {
-                this(name, data, mimeType, null);
-            }
-
-            public Attachment(final String name, final byte[] data, final String mimeType, final String description) {
-                this(name, data, mimeType, description, null);
-            }
-
-            public Attachment(final String name, final byte[] data, final String mimeType, final String description, final String disposition) {
-                if (name == null || name.trim().isEmpty()) {
-                    throw new RuntimeException("Name must not be null or empty");
-                }
-                if (data == null) {
-                    throw new RuntimeException("Data must not be null");
-                }
-                this.name = name;
-                this.data = data;
-                this.mimeType = mimeType;
-                this.description = description;
-                this.disposition = disposition;
-            }
-
-            public Attachment(final String name, final File file) {
-                this(name, file, null);
-            }
-
-            public Attachment(final String name, final File file, String description) {
-                this(name, file, description, null);
-            }
-
-            public Attachment(final String name, final File file, final String description, final String disposition) {
-                if (name == null || name.trim().isEmpty()) {
-                    throw new RuntimeException("Name must not be null or empty");
-                }
-                if (file == null) {
-                    throw new RuntimeException("File must not be null");
-                }
-                this.name = name;
-                this.file = file;
-                this.description = description;
-                this.disposition = disposition;
-            }
-
-            public byte[] getData() {
-                return this.data;
-            }
-
-            public String getMimeType() {
-                return this.mimeType;
-            }
-
-            public File getFile() {
-                return this.file;
-            }
-
-            public String getName() {
-                return this.name;
-            }
-
-            public String getDescription() {
-                return this.description;
-            }
-
-            public String getDisposition() {
-                return this.disposition;
-            }
-        }
-
-        private final String subject;
-        private final String[] recipients;
-        private final String[] cc;
-        private final String[] bcc;
-        private String from;
-        private final Body body;
-        private String replyTo;
-
-        private final Map<String, List<String>> customHeaders;
-        private final List<Attachment> attachments = new ArrayList<Attachment>(1);
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients) {
-            this(subject, body, recipients, null, null, null, null);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients, final String[] cc) {
-            this(subject, body, recipients, cc, null, null, null);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients, final String[] cc, final String[] bcc) {
-            this(subject, body, recipients, cc, bcc, null, null);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients, final String replyTo) {
-            this(subject, body, recipients, null, null, null, replyTo);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients, final String[] cc, final String replyTo) {
-            this(subject, body, recipients, cc, null, null, replyTo);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients, final String[] cc, final String[] bcc, final String replyTo) {
-            this(subject, body, recipients, cc, bcc, null, replyTo);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients,
-                    final Map<String, List<String>> customHeaders) {
-            this(subject, body, recipients, null, null, customHeaders, null);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients, final String[] cc,
-                    final Map<String, List<String>> customHeaders) {
-            this(subject, body, recipients, cc, null, customHeaders, null);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients, final String[] cc, final String[] bcc,
-                    final Map<String, List<String>> customHeaders) {
-            this(subject, body, recipients, cc, bcc, customHeaders, null);
-        }
-
-        public Mail(final String subject, final Body body,
-                    final String[] recipients, final String[] cc, final String[] bcc,
-                    final Map<String, List<String>> customHeaders, final String replyTo) {
-            if (subject == null || subject.trim().isEmpty()) {
-                throw new RuntimeException("Subject must not be null or empty");
-            }
-            this.subject = subject;
-
-            if (body == null) {
-                throw new RuntimeException("Body must not be null or empty");
-            }
-
-            this.body = body;
-
-            if (recipients == null || recipients.length == 0) {
-                throw new RuntimeException(
-                        "There must be at least one recipient");
-            }
-            this.recipients = recipients;
-
-            this.cc = cc;
-            this.bcc = bcc;
-
-            if (customHeaders != null) {
-                this.customHeaders = customHeaders;
-            } else {
-                this.customHeaders = new HashMap<String, List<String>>(1);
-            }
-
-            if (replyTo != null) {
-                this.replyTo = replyTo;
-            }
-        }
-
-
-        public String getSubject() {
-            return subject;
-        }
-
-        public String[] getRecipients() {
-            return recipients;
-        }
-
-        public String[] getCc() {
-            return cc;
-        }
-
-        public String[] getBcc() {
-            return bcc;
-        }
-
-        public String getFrom() {
-            return from;
-        }
-
-        private void setFrom(final String from) {
-            this.from = from;
-        }
-
-        public String getReplyTo() {
-            return replyTo;
-        }
-
-        public void setReplyTo(final String replyTo) {
-            this.replyTo = replyTo;
-        }
-
-        public Body getBody() {
-            return body;
-        }
-
-        public Map<String, List<String>> getCustomHeaders() {
-            return customHeaders;
-        }
-
-        public void addCustomHeader(String name, String... values) {
-            this.customHeaders.put(name, Arrays.asList(values));
-        }
-
-        public List<Attachment> getAttachments() {
-            return attachments;
-        }
-
-        public void addAttachment(final Attachment... attachments) {
-            this.attachments.addAll(Arrays.asList(attachments));
-        }
     }
 
     private class MailJob implements Runnable {
@@ -382,51 +264,10 @@ public class Mailer {
 
         @Override
         public void run() {
-            final Email email = new Email();
-
-            email.setSubject(mail.getSubject());
-            email.setTo(Arrays.asList(mail.getRecipients()));
-            if (mail.getCc() != null) {
-                email.setCc(Arrays.asList(mail.getCc()));
+        	if (includeXMailerHeader) {
+        		mail.addHeader("X-Mailer", MAILER + getVersion());
             }
-            if (mail.getBcc() != null) {
-                email.setBcc(Arrays.asList(mail.getBcc()));
-            }
-            email.setFrom(mail.getFrom());
-            if (includeXMailerHeader) {
-                email.addHeader("X-Mailer", MAILER + getVersion());
-            }
-
-            for (final Entry<String, List<String>> entry : mail
-                    .getCustomHeaders().entrySet()) {
-                final String headerName = entry.getKey();
-                for (final String headerValue : entry.getValue()) {
-                    email.addHeader(headerName, headerValue);
-                }
-            }
-            if (mail.getReplyTo() != null) {
-                email.setReplyTo(mail.getReplyTo());
-            }
-            for (final Mail.Attachment attachment : mail.getAttachments()) {
-                if (attachment.getData() != null) {
-                    email.addAttachment(attachment.getName(), attachment.getData(), attachment.getMimeType(), attachment.getDescription(), attachment.getDisposition());
-                } else {
-                    email.addAttachment(attachment.getName(), attachment.getFile(), attachment.getDescription(), attachment.getDisposition());
-                }
-            }
-            if (mail.getBody().isBoth()) {
-                // sends both text and html
-                email.setBodyText(mail.getBody().getText());
-                email.setBodyHtml(mail.getBody().getHtml());
-            } else if (mail.getBody().isText()) {
-                // sends text/text
-            	email.setBodyText(mail.getBody().getText());
-            } else {
-                // if(mail.isHtml())
-                // sends html
-                email.setBodyHtml(mail.getBody().getHtml());
-            }
-            MailerPlugin.send(email);
+        	MailerPlugin.send(mail);
         }
 
     }
@@ -441,13 +282,13 @@ public class Mailer {
     }
 
     public Cancellable sendMail(final String subject, final String textBody, final String recipient) {
-        final Mail mail = new Mail(subject, new Body(textBody), new String[]{recipient});
+        final Mail mail = new Mail(subject, new Mail.Body(textBody), Arrays.asList(new String[]{recipient}));
         return sendMail(mail);
     }
 
-    public Cancellable sendMail(final String subject, final Body body,
+    public Cancellable sendMail(final String subject, final Mail.Body body,
                                 final String recipient) {
-        final Mail mail = new Mail(subject, body, new String[]{recipient});
+        final Mail mail = new Mail(subject, body, Arrays.asList(new String[]{recipient}));
         return sendMail(mail);
     }
 }

--- a/code/app/com/feth/play/module/mail/Mailer.java
+++ b/code/app/com/feth/play/module/mail/Mailer.java
@@ -13,7 +13,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 public class Mailer {
-	
+
     private static final String MAILER = "play-easymail/";
 
     private static final String CONFIG_BASE = "play-easymail";
@@ -74,137 +74,147 @@ public class Mailer {
 
         return sb.toString();
     }
-    
+
+    protected Mailer(final Configuration config) {
+        this.delay = Duration.create(config.getLong(SettingKeys.DELAY, 1L), TimeUnit.SECONDS);
+
+        final Configuration fromConfig = config.getConfig(SettingKeys.FROM);
+        this.sender = getEmailName(fromConfig.getString(SettingKeys.FROM_EMAIL),
+                fromConfig.getString(SettingKeys.FROM_NAME));
+
+        this.includeXMailerHeader = config.getBoolean(SettingKeys.INCLUDE_XMAILER_HEADER, true);
+    }
+
     public static class Mail extends Email {
-        
-        
+
+
         public static class HtmlBody extends Body {
-            
+
             public HtmlBody(final String text) {
                 super(null, text);
             }
-            
+
         }
-        
+
         public static class TxtBody extends Body {
-            
+
             public TxtBody(final String text) {
                 super(text, null);
             }
-            
+
         }
-        
+
         public static class Body {
             private final String html;
             private final String text;
             private final boolean isHtml;
             private final boolean isText;
-            
+
             public Body(final String text) {
                 this(text, null);
             }
-            
+
             public Body(final String text, final String html) {
                 this.isHtml = html != null && !html.trim().isEmpty();
                 this.isText = text != null && !text.trim().isEmpty();
-                
+
                 if (!this.isHtml && !this.isText) {
                     throw new RuntimeException(
-                                               "Text and HTML cannot both be empty or null");
+                            "Text and HTML cannot both be empty or null");
                 }
                 this.html = (this.isHtml) ? html : null;
                 this.text = (this.isText) ? text : null;
             }
-            
+
             public boolean isHtml() {
-                return isHtml;
+                return this.isHtml;
             }
-            
+
             public boolean isText() {
-                return isText;
+                return this.isText;
             }
-            
+
             public boolean isBoth() {
                 return isText() && isHtml();
             }
-            
+
             public String getHtml() {
-                return html;
+                return this.html;
             }
-            
+
             public String getText() {
-                return text;
+                return this.text;
             }
         }
-        
+
         public Mail(final String subject, final String body,
-                    final String recipients) {
-            this(subject, new Body(body), new String[]{recipients});
+                    final String recipient) {
+            this(subject, new Body(body), new String[]{recipient});
         }
-        
+
         public Mail(final String subject, final String body,
-                    final List<String> recipients) {
-            this(subject, new Body(body), recipients);
+                    final List<String> recipient) {
+            this(subject, new Body(body), recipient);
         }
-        
+
         public Mail(final String subject, final Body body,
-                    final String recipients) {
-            this(subject, body, new String[]{recipients});
+                    final String recipient) {
+            this(subject, body, new String[]{recipient});
         }
-        
+
         public Mail(final String subject, final Body body,
                     final String[] recipients) {
             this(subject, body, Arrays.asList(recipients));
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients) {
             this(subject, body, recipients, null, null, null, null);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients, final List<String> cc) {
             this(subject, body, recipients, cc, null, null, null);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients, final List<String> cc, final List<String> bcc) {
             this(subject, body, recipients, cc, bcc, null, null);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients, final String replyTo) {
             this(subject, body, recipients, null, null, null, replyTo);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients, final List<String> cc, final String replyTo) {
             this(subject, body, recipients, cc, null, null, replyTo);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients, final List<String> cc, final List<String> bcc, final String replyTo) {
             this(subject, body, recipients, cc, bcc, null, replyTo);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients,
                     final Map<String, List<String>> customHeaders) {
             this(subject, body, recipients, null, null, customHeaders, null);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients, final List<String> cc,
                     final Map<String, List<String>> customHeaders) {
             this(subject, body, recipients, cc, null, customHeaders, null);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients, final List<String> cc, final List<String> bcc,
                     final Map<String, List<String>> customHeaders) {
             this(subject, body, recipients, cc, bcc, customHeaders, null);
         }
-        
+
         public Mail(final String subject, final Body body,
                     final List<String> recipients, final List<String> cc, final List<String> bcc,
                     final Map<String, List<String>> customHeaders, final String replyTo) {
@@ -212,22 +222,22 @@ public class Mailer {
                 throw new RuntimeException("Subject must not be null or empty");
             }
             this.setSubject(subject);
-            
+
             if (body == null) {
                 throw new RuntimeException("Body must not be null or empty");
             }
             if(body.isText())this.setBodyText(body.getText());
             if(body.isHtml())this.setBodyHtml(body.getHtml());
-            
+
             if (recipients == null || recipients.size() == 0) {
                 throw new RuntimeException(
-                                           "There must be at least one recipient");
+                        "There must be at least one recipient");
             }
             this.setTo(recipients);
-            
+
             if (cc != null && cc.size() > 0) this.setCc(cc);
             if (bcc != null && bcc.size() > 0) this.setBcc(bcc);
-            
+
             if (customHeaders != null) {
                 for (final Entry<String, List<String>> entry : customHeaders.entrySet()) {
                     final String headerName = entry.getKey();
@@ -244,51 +254,41 @@ public class Mailer {
         }
     }
 
-    protected Mailer(final Configuration config) {
-        delay = Duration.create(config.getLong(SettingKeys.DELAY, 1L), TimeUnit.SECONDS);
-
-        final Configuration fromConfig = config.getConfig(SettingKeys.FROM);
-        sender = getEmailName(fromConfig.getString(SettingKeys.FROM_EMAIL),
-                fromConfig.getString(SettingKeys.FROM_NAME));
-
-        includeXMailerHeader = config.getBoolean(SettingKeys.INCLUDE_XMAILER_HEADER, true);
-    }
-
     private class MailJob implements Runnable {
 
         private Mail mail;
 
         public MailJob(final Mail m) {
-            mail = m;
+            this.mail = m;
         }
 
         @Override
         public void run() {
-        	if (includeXMailerHeader) {
-        		mail.addHeader("X-Mailer", MAILER + getVersion());
+            if (Mailer.this.includeXMailerHeader) {
+                this.mail.addHeader("X-Mailer", MAILER + getVersion());
             }
-        	MailerPlugin.send(mail);
+            MailerPlugin.send(this.mail);
         }
 
     }
 
     public Cancellable sendMail(final Mail email) {
-        email.setFrom(sender);
+        email.setFrom(this.sender);
         return Akka
                 .system()
                 .scheduler()
-                .scheduleOnce(delay, new MailJob(email),
+                .scheduleOnce(this.delay, new MailJob(email),
                         Akka.system().dispatcher());
     }
 
     public Cancellable sendMail(final String subject, final String textBody, final String recipient) {
-        final Mail mail = new Mail(subject, new Mail.Body(textBody), Arrays.asList(new String[]{recipient}));
+        final Mail mail = new Mail(subject, new Mail.Body(textBody), Arrays.asList(recipient));
         return sendMail(mail);
     }
 
     public Cancellable sendMail(final String subject, final Mail.Body body,
                                 final String recipient) {
-        final Mail mail = new Mail(subject, body, Arrays.asList(new String[]{recipient}));
+        final Mail mail = new Mail(subject, body, Arrays.asList(recipient));
         return sendMail(mail);
     }
 }

--- a/code/build.sbt
+++ b/code/build.sbt
@@ -10,5 +10,4 @@ libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-mailer" % "3.0.1"
 )
 
-lazy val `play-easymail` = (project in file("."))
-  .enablePlugins(PlayJava)
+lazy val root = (project in file(".")).enablePlugins(PlayJava)

--- a/code/build.sbt
+++ b/code/build.sbt
@@ -1,15 +1,14 @@
-import play.PlayJava
-
 organization := "com.feth"
 
 name := "play-easymail"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.6"
 
-crossScalaVersions := Seq("2.10.4", "2.11.2")
+crossScalaVersions := Seq("2.10.5", "2.11.6")
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play" %% "play-mailer" % "2.4.1"
+  "com.typesafe.play" %% "play-mailer" % "3.0.1"
 )
 
-lazy val root = (project in file(".")).enablePlugins(PlayJava)
+lazy val `play-easymail` = (project in file("."))
+  .enablePlugins(PlayJava)

--- a/code/conf/play.plugins
+++ b/code/conf/play.plugins
@@ -1,1 +1,0 @@
-1500:play.api.libs.mailer.CommonsMailerPlugin

--- a/code/conf/reference.conf
+++ b/code/conf/reference.conf
@@ -1,6 +1,6 @@
 # play-easymail default configuration
 play-easymail {
-    version=“0.7.0”
+    version="0.7.0"
 
     # Whether to add the X-Mailer header or not
     includeXMailerHeader=true

--- a/code/conf/reference.conf
+++ b/code/conf/reference.conf
@@ -1,6 +1,6 @@
 # play-easymail default configuration
 play-easymail {
-    version="0.6.5"
+    version=“0.7.0”
 
     # Whether to add the X-Mailer header or not
     includeXMailerHeader=true

--- a/code/project/build.properties
+++ b/code/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/code/project/plugins.sbt
+++ b/code/project/plugins.sbt
@@ -12,5 +12,3 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("pla
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
-
-

--- a/code/project/plugins.sbt
+++ b/code/project/plugins.sbt
@@ -7,8 +7,10 @@ resolvers += "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesa
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.3.6"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.4.0"))
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
+
+

--- a/code/version.sbt
+++ b/code/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.7.0"
+version in ThisBuild := "0.7.0-SNAPSHOT"

--- a/code/version.sbt
+++ b/code/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.8-SNAPSHOT"
+version in ThisBuild := "0.7.0"

--- a/samples/play-easymail-usage/app/controllers/Application.java
+++ b/samples/play-easymail-usage/app/controllers/Application.java
@@ -1,7 +1,7 @@
 package controllers;
 
 import com.feth.play.module.mail.Mailer;
-import com.feth.play.module.mail.Mailer.Mail.Attachment;
+import com.feth.play.module.mail.Mailer.Mail;
 import com.feth.play.module.mail.Mailer.Mail.Body;
 
 import java.io.File;
@@ -11,11 +11,10 @@ import org.apache.commons.mail.EmailAttachment;
 import play.data.Form;
 import play.data.validation.Constraints.Email;
 import play.data.validation.Constraints.Required;
+import play.libs.mailer.MailerPlugin;
 import play.mvc.*;
 import play.Play;
-
 import views.html.index;
-
 import static play.data.Form.form;
 
 public class Application extends Controller {
@@ -24,6 +23,15 @@ public class Application extends Controller {
         @Email
         @Required
         public String email;
+
+		public String getEmail() {
+			return email;
+		}
+
+		public void setEmail(String email) {
+			this.email = email;
+		}
+        
     }
 
     private static final Form<MailMe> FORM = form(MailMe.class);
@@ -51,11 +59,11 @@ public class Application extends Controller {
 
             {
                 // advanced usage
-                final Mailer.Mail customMail = new Mailer.Mail("play-easymail | advanced", body, new String[]{ email });
-                customMail.addCustomHeader("Reply-To", email);
-                customMail.addAttachment(new Attachment("attachment.pdf", Play.application().getFile("conf/sample.pdf")));
+                final Mail customMail = new Mail("play-easymail | advanced", body, new String[]{ email });
+                customMail.addHeader("Reply-To", email);
+                customMail.addAttachment("attachment.pdf", Play.application().getFile("conf/sample.pdf"));
                 byte[] data = "data".getBytes();
-                customMail.addAttachment(new Attachment("data.txt", data, "text/plain", "A simple file", EmailAttachment.INLINE));
+                customMail.addAttachment("data.txt", data, "text/plain", "A simple file", EmailAttachment.INLINE);
                 defaultMailer.sendMail(customMail);
             }
 

--- a/samples/play-easymail-usage/app/controllers/Application.java
+++ b/samples/play-easymail-usage/app/controllers/Application.java
@@ -11,7 +11,6 @@ import org.apache.commons.mail.EmailAttachment;
 import play.data.Form;
 import play.data.validation.Constraints.Email;
 import play.data.validation.Constraints.Required;
-import play.libs.mailer.MailerPlugin;
 import play.mvc.*;
 import play.Play;
 import views.html.index;
@@ -22,16 +21,16 @@ public class Application extends Controller {
     public static class MailMe {
         @Email
         @Required
-        public String email;
+        private String email;
 
-		public String getEmail() {
-			return email;
-		}
+        public String getEmail() {
+            return this.email;
+        }
 
-		public void setEmail(String email) {
-			this.email = email;
-		}
-        
+        public void setEmail(String email) {
+            this.email = email;
+        }
+
     }
 
     private static final Form<MailMe> FORM = form(MailMe.class);

--- a/samples/play-easymail-usage/app/views/index.scala.html
+++ b/samples/play-easymail-usage/app/views/index.scala.html
@@ -2,7 +2,7 @@
 
 @import helper._
 
-@main("Welcome to Play 2.0") {
+@main("Welcome to Play 2.4") {
     
     @form(routes.Application.sendMail) {
     	@inputText(

--- a/samples/play-easymail-usage/build.sbt
+++ b/samples/play-easymail-usage/build.sbt
@@ -6,8 +6,7 @@ version := "1.0-SNAPSHOT"
 
 libraryDependencies ++= Seq(
   // Comment the next line for local development:
-  "com.feth" %% "play-easymail" % "0.7.0",
-  javaCore
+  "com.feth" %% "play-easymail" % "0.7.0-SNAPSHOT"
 )
 
 resolvers ++= Seq(
@@ -18,7 +17,7 @@ resolvers ++= Seq(
 //  Uncomment the next line for local development of the Play Authenticate core:
 //lazy val playEasymail = project.in(file("modules/play-easymail")).enablePlugins(PlayJava)
 
-lazy val `play-easymail-usage` = (project in file("."))
+lazy val root = (project in file("."))
   .enablePlugins(PlayJava)
 /*  Uncomment the next lines for local development of the Play Authenticate core: */
 //  .dependsOn(playEasymail)

--- a/samples/play-easymail-usage/build.sbt
+++ b/samples/play-easymail-usage/build.sbt
@@ -1,14 +1,12 @@
-import play.PlayJava
-
 name := "play-easymail-usage"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.6"
 
 version := "1.0-SNAPSHOT"
 
 libraryDependencies ++= Seq(
   // Comment the next line for local development:
-  "com.feth" %% "play-easymail" % "0.6.8-SNAPSHOT",
+  "com.feth" %% "play-easymail" % "0.7.0",
   javaCore
 )
 
@@ -20,7 +18,7 @@ resolvers ++= Seq(
 //  Uncomment the next line for local development of the Play Authenticate core:
 //lazy val playEasymail = project.in(file("modules/play-easymail")).enablePlugins(PlayJava)
 
-lazy val root = (project in file("."))
+lazy val `play-easymail-usage` = (project in file("."))
   .enablePlugins(PlayJava)
 /*  Uncomment the next lines for local development of the Play Authenticate core: */
 //  .dependsOn(playEasymail)

--- a/samples/play-easymail-usage/conf/application.conf
+++ b/samples/play-easymail-usage/conf/application.conf
@@ -9,7 +9,7 @@ application.secret="/Z7ciU0rgue>EaaIbPO9cnULYRHpPNElh`e3PY_i6SfHefOPOHxmq7PXoGZP
 
 # The application languages
 # ~~~~~
-application.langs="en"
+play.modules.i18n.langs="en"
 
 # Logger
 # ~~~~~

--- a/samples/play-easymail-usage/conf/application.conf
+++ b/samples/play-easymail-usage/conf/application.conf
@@ -5,24 +5,11 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="/Z7ciU0rgue>EaaIbPO9cnULYRHpPNElh`e3PY_i6SfHefOPOHxmq7PXoGZPXp:y"
+play.crypto.secret="/Z7ciU0rgue>EaaIbPO9cnULYRHpPNElh`e3PY_i6SfHefOPOHxmq7PXoGZPXp:y"
 
 # The application languages
 # ~~~~~
-play.modules.i18n.langs="en"
-
-# Logger
-# ~~~~~
-# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory .
-
-# Root logger:
-logger.root=ERROR
-
-# Logger used by the framework:
-logger.play=INFO
-
-# Logger provided to your application:
-logger.application=DEBUG
+play.i18n.langs = [ "en" ]
 
 # SMTP configuration
 include "smtp.conf"

--- a/samples/play-easymail-usage/project/build.properties
+++ b/samples/play-easymail-usage/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/samples/play-easymail-usage/project/plugins.sbt
+++ b/samples/play-easymail-usage/project/plugins.sbt
@@ -5,4 +5,6 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.3.6"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.4.0"))
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0-RC2")
+

--- a/samples/play-easymail-usage/project/plugins.sbt
+++ b/samples/play-easymail-usage/project/plugins.sbt
@@ -6,5 +6,3 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 
 // Use the Play sbt plugin for Play projects
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % Option(System.getProperty("play.version")).getOrElse("2.4.0"))
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "4.0.0-RC2")
-


### PR DESCRIPTION
I squashed the commits from @vmouta from #38 into one nice, single commit.
Then I cleaned up the code a bit.

I also support the strategy vmouta is taking by extending Play's `Email` class, which saves us a lot of redundant code (e.g. we do not need the `Attachment` class anymore) because basically all functionality is implemented by the play-mailer module already.

One more thing: This PR does not use dependency injection yet (The `MailerPlugin` is deprecated) . It's ok for now, but for Play 3.0 this has to be addressed, as Plugins will be removed in favor of Modules written with DI.

@joscha Could you please review this PR and if you are fine with it merge and release a snapshot so people can test?